### PR TITLE
Feature/#28 fix domain

### DIFF
--- a/fastcampus-project-board/src/main/java/com/fastcampus/fastcampusprojectboard/domain/UserAccount.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/fastcampusprojectboard/domain/UserAccount.java
@@ -8,7 +8,7 @@ import java.util.Objects;
 @Getter
 @ToString
 @Table(indexes = {
-        @Index(columnList = "userId"),
+        @Index(columnList = "userId", unique = true),
         @Index(columnList = "email", unique = true),
         @Index(columnList = "createdAt"),
         @Index(columnList = "createdBy")

--- a/fastcampus-project-board/src/test/java/com/fastcampus/fastcampusprojectboard/repository/JpaRepositoryTest.java
+++ b/fastcampus-project-board/src/test/java/com/fastcampus/fastcampusprojectboard/repository/JpaRepositoryTest.java
@@ -55,7 +55,7 @@ class JpaRepositoryTest {
     void givenTestData_whenInserting_thenWorksFine() {
         // Given
         long previousCount = articleRepository.count();
-        UserAccount userAccount = userAccountRepository.save(UserAccount.of("uno", "pw", null, null, null));
+        UserAccount userAccount = userAccountRepository.save(UserAccount.of("jsun", "pw", null, null, null));
         Article article = Article.of(userAccount, "new article", "new content", "#spring");
 
         // When


### PR DESCRIPTION
회원 id로 로그인하고 유저 식별하므로, 당연히 uk 여야 한다.
이 부분이 설계에서 반영되지 않았던 것을 발견
테스트는 uk 적용으로 기존 `data.sql`의 테스트 데이터와
중복이 발생하므로 `userId` 이름을 수정