### PR TITLE
AuditingFields: Modify Field Access Modifier to protected

### DIFF
--- a/src/main/java/com/fastcampus/fastcampusprojectboard/domain/AuditingFields.java
+++ b/src/main/java/com/fastcampus/fastcampusprojectboard/domain/AuditingFields.java
@@ -23,18 +23,18 @@ public class AuditingFields {
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @CreatedDate
     @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt;
+    protected LocalDateTime createdAt;
 
     @CreatedBy
     @Column(nullable = false, length = 100, updatable = false)
-    private String createdBy;
+    protected String createdBy;
 
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @LastModifiedDate
     @Column(nullable = false)
-    private LocalDateTime updatedAt;
+    protected LocalDateTime updatedAt;
 
     @LastModifiedBy
     @Column(nullable = false,length = 100)
-    private String updatedBy;
+    protected String updatedBy;
 }


### PR DESCRIPTION
This section should originally have been protected to align with the nature of an abstract class. However, the initial design was overly restrictive.

Now, the member entity needs to directly reference this part, so it has been properly adjusted.

With this change, member information can be stored without authentication in the constructor.

The scenarios where this is needed include member registration and member creation.